### PR TITLE
Initialize Hubbers Java 21 monolith prototype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,91 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.hubbers</groupId>
+    <artifactId>hubbers</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>hubbers</name>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jackson.version>2.17.2</jackson.version>
+        <picocli.version>4.7.6</picocli.version>
+        <slf4j.version>2.0.16</slf4j.version>
+        <junit.version>5.11.3</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>${picocli.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.8</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.hubbers.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/repo/agents/text.summarizer/agent.yaml
+++ b/repo/agents/text.summarizer/agent.yaml
@@ -1,0 +1,31 @@
+agent:
+  name: text.summarizer
+  version: 1.0.0
+  description: Summarize text in Italian
+
+model:
+  provider: openai
+  name: gpt-4.1-mini
+  temperature: 0.2
+
+instructions:
+  system_prompt: |
+    Riassumi il testo in italiano in massimo 5 punti.
+
+input:
+  schema:
+    type: object
+    properties:
+      text:
+        type: string
+        required: true
+
+output:
+  schema:
+    type: object
+    properties:
+      summary:
+        type: string
+        required: true
+
+tools: []

--- a/repo/pipelines/pdf.summary/pipeline.yaml
+++ b/repo/pipelines/pdf.summary/pipeline.yaml
@@ -1,0 +1,13 @@
+pipeline:
+  name: pdf.summary
+  version: 1.0.0
+  description: Extract text from PDF and summarize it
+
+steps:
+  - id: extract
+    tool: pdf.extract
+
+  - id: summarize
+    agent: text.summarizer
+    input_mapping:
+      text: ${steps.extract.output.text}

--- a/repo/tools/pdf.extract/tool.yaml
+++ b/repo/tools/pdf.extract/tool.yaml
@@ -1,0 +1,25 @@
+tool:
+  name: pdf.extract
+  version: 1.0.0
+  description: Extract text from PDF
+
+type: docker
+
+config:
+  image: myorg/pdf-extract:1.0.0
+
+input:
+  schema:
+    type: object
+    properties:
+      file_path:
+        type: string
+        required: true
+
+output:
+  schema:
+    type: object
+    properties:
+      text:
+        type: string
+        required: true

--- a/repo/tools/weather.lookup/tool.yaml
+++ b/repo/tools/weather.lookup/tool.yaml
@@ -1,0 +1,26 @@
+tool:
+  name: weather.lookup
+  version: 1.0.0
+  description: Lookup weather using external API
+
+type: http
+
+config:
+  base_url: https://example.com/api/weather
+  method: POST
+
+input:
+  schema:
+    type: object
+    properties:
+      city:
+        type: string
+        required: true
+
+output:
+  schema:
+    type: object
+    properties:
+      temperature:
+        type: number
+        required: true

--- a/src/main/java/org/hubbers/Main.java
+++ b/src/main/java/org/hubbers/Main.java
@@ -1,0 +1,12 @@
+package org.hubbers;
+
+import org.hubbers.app.Bootstrap;
+import org.hubbers.cli.HubbersCommand;
+import picocli.CommandLine;
+
+public class Main {
+    public static void main(String[] args) {
+        int exitCode = new CommandLine(new HubbersCommand(Bootstrap.createRuntimeFacade())).execute(args);
+        System.exit(exitCode);
+    }
+}

--- a/src/main/java/org/hubbers/agent/AgentExecutor.java
+++ b/src/main/java/org/hubbers/agent/AgentExecutor.java
@@ -1,0 +1,61 @@
+package org.hubbers.agent;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.hubbers.execution.ExecutionMetadata;
+import org.hubbers.execution.RunResult;
+import org.hubbers.manifest.agent.AgentManifest;
+import org.hubbers.model.ModelProvider;
+import org.hubbers.model.ModelProviderRegistry;
+import org.hubbers.model.ModelRequest;
+import org.hubbers.model.ModelResponse;
+import org.hubbers.validation.SchemaValidator;
+import org.hubbers.validation.ValidationResult;
+
+public class AgentExecutor {
+    private final ModelProviderRegistry modelProviderRegistry;
+    private final AgentPromptBuilder promptBuilder;
+    private final SchemaValidator schemaValidator;
+    private final ObjectMapper mapper;
+
+    public AgentExecutor(ModelProviderRegistry modelProviderRegistry,
+                         AgentPromptBuilder promptBuilder,
+                         SchemaValidator schemaValidator,
+                         ObjectMapper mapper) {
+        this.modelProviderRegistry = modelProviderRegistry;
+        this.promptBuilder = promptBuilder;
+        this.schemaValidator = schemaValidator;
+        this.mapper = mapper;
+    }
+
+    public RunResult execute(AgentManifest manifest, JsonNode input) {
+        ValidationResult inputValidation = schemaValidator.validate(input, manifest.getInput().getSchema());
+        if (!inputValidation.isValid()) {
+            return RunResult.failed(String.join(", ", inputValidation.getErrors()));
+        }
+
+        AgentRunContext context = new AgentRunContext();
+        context.setManifest(manifest);
+        context.setInput(input);
+
+        ModelRequest request = promptBuilder.build(context);
+        ModelProvider provider = modelProviderRegistry.get(manifest.getModel().getProvider());
+        ModelResponse modelResponse = provider.generate(request);
+
+        ObjectNode output = mapper.createObjectNode();
+        output.put("summary", modelResponse.getContent());
+        ValidationResult outputValidation = schemaValidator.validate(output, manifest.getOutput().getSchema());
+        if (!outputValidation.isValid()) {
+            return RunResult.failed(String.join(", ", outputValidation.getErrors()));
+        }
+
+        RunResult result = RunResult.success(output);
+        ExecutionMetadata metadata = new ExecutionMetadata();
+        metadata.setStartedAt(System.currentTimeMillis() - modelResponse.getLatencyMs());
+        metadata.setEndedAt(System.currentTimeMillis());
+        metadata.setDetails("model=" + modelResponse.getModel() + ", latencyMs=" + modelResponse.getLatencyMs());
+        result.setMetadata(metadata);
+        return result;
+    }
+}

--- a/src/main/java/org/hubbers/agent/AgentPromptBuilder.java
+++ b/src/main/java/org/hubbers/agent/AgentPromptBuilder.java
@@ -1,0 +1,25 @@
+package org.hubbers.agent;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hubbers.manifest.agent.AgentManifest;
+import org.hubbers.model.ModelRequest;
+import org.hubbers.util.JacksonFactory;
+
+public class AgentPromptBuilder {
+    private final ObjectMapper mapper = JacksonFactory.jsonMapper();
+
+    public ModelRequest build(AgentRunContext context) {
+        AgentManifest manifest = context.getManifest();
+        ModelRequest request = new ModelRequest();
+        request.setSystemPrompt(manifest.getInstructions().getSystemPrompt());
+        request.setModel(manifest.getModel().getName());
+        request.setTemperature(manifest.getModel().getTemperature());
+        try {
+            request.setUserPrompt(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(context.getInput()));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Cannot serialize input", e);
+        }
+        return request;
+    }
+}

--- a/src/main/java/org/hubbers/agent/AgentRunContext.java
+++ b/src/main/java/org/hubbers/agent/AgentRunContext.java
@@ -1,0 +1,14 @@
+package org.hubbers.agent;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.hubbers.manifest.agent.AgentManifest;
+
+public class AgentRunContext {
+    private AgentManifest manifest;
+    private JsonNode input;
+
+    public AgentManifest getManifest() { return manifest; }
+    public void setManifest(AgentManifest manifest) { this.manifest = manifest; }
+    public JsonNode getInput() { return input; }
+    public void setInput(JsonNode input) { this.input = input; }
+}

--- a/src/main/java/org/hubbers/app/Bootstrap.java
+++ b/src/main/java/org/hubbers/app/Bootstrap.java
@@ -1,0 +1,48 @@
+package org.hubbers.app;
+
+import org.hubbers.agent.AgentExecutor;
+import org.hubbers.agent.AgentPromptBuilder;
+import org.hubbers.artifact.ArtifactScanner;
+import org.hubbers.artifact.LocalArtifactRepository;
+import org.hubbers.config.ConfigLoader;
+import org.hubbers.model.ModelProviderRegistry;
+import org.hubbers.model.OpenAiModelProvider;
+import org.hubbers.pipeline.InputMapper;
+import org.hubbers.pipeline.PipelineExecutor;
+import org.hubbers.tool.DockerToolDriver;
+import org.hubbers.tool.HttpToolDriver;
+import org.hubbers.tool.ToolExecutor;
+import org.hubbers.util.JacksonFactory;
+import org.hubbers.validation.ManifestValidator;
+import org.hubbers.validation.SchemaValidator;
+
+import java.net.http.HttpClient;
+import java.nio.file.Path;
+import java.util.List;
+
+public class Bootstrap {
+
+    public static RuntimeFacade createRuntimeFacade() {
+        var config = new ConfigLoader().load();
+        var jsonMapper = JacksonFactory.jsonMapper();
+        var httpClient = HttpClient.newHttpClient();
+
+        var repository = new LocalArtifactRepository(Path.of(config.getRepoRoot()), new ArtifactScanner());
+
+        var modelRegistry = new ModelProviderRegistry(List.of(
+                new OpenAiModelProvider(httpClient, config.getOpenai())
+        ));
+
+        var schemaValidator = new SchemaValidator();
+        var agentExecutor = new AgentExecutor(modelRegistry, new AgentPromptBuilder(), schemaValidator, jsonMapper);
+
+        var toolExecutor = new ToolExecutor(List.of(
+                new HttpToolDriver(httpClient, jsonMapper),
+                new DockerToolDriver(jsonMapper)
+        ), schemaValidator);
+
+        var pipelineExecutor = new PipelineExecutor(repository, agentExecutor, toolExecutor, new InputMapper(jsonMapper));
+
+        return new RuntimeFacade(repository, agentExecutor, toolExecutor, pipelineExecutor, new ManifestValidator());
+    }
+}

--- a/src/main/java/org/hubbers/app/RuntimeFacade.java
+++ b/src/main/java/org/hubbers/app/RuntimeFacade.java
@@ -1,0 +1,56 @@
+package org.hubbers.app;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.hubbers.agent.AgentExecutor;
+import org.hubbers.artifact.ArtifactRepository;
+import org.hubbers.execution.RunResult;
+import org.hubbers.pipeline.PipelineExecutor;
+import org.hubbers.tool.ToolExecutor;
+import org.hubbers.validation.ManifestValidator;
+
+import java.util.List;
+
+public class RuntimeFacade {
+    private final ArtifactRepository artifactRepository;
+    private final AgentExecutor agentExecutor;
+    private final ToolExecutor toolExecutor;
+    private final PipelineExecutor pipelineExecutor;
+    private final ManifestValidator manifestValidator;
+
+    public RuntimeFacade(ArtifactRepository artifactRepository,
+                         AgentExecutor agentExecutor,
+                         ToolExecutor toolExecutor,
+                         PipelineExecutor pipelineExecutor,
+                         ManifestValidator manifestValidator) {
+        this.artifactRepository = artifactRepository;
+        this.agentExecutor = agentExecutor;
+        this.toolExecutor = toolExecutor;
+        this.pipelineExecutor = pipelineExecutor;
+        this.manifestValidator = manifestValidator;
+    }
+
+    public RunResult runAgent(String name, JsonNode input) {
+        var manifest = artifactRepository.loadAgent(name);
+        var validation = manifestValidator.validateAgent(manifest);
+        if (!validation.isValid()) return RunResult.failed(String.join(", ", validation.getErrors()));
+        return agentExecutor.execute(manifest, input);
+    }
+
+    public RunResult runTool(String name, JsonNode input) {
+        var manifest = artifactRepository.loadTool(name);
+        var validation = manifestValidator.validateTool(manifest);
+        if (!validation.isValid()) return RunResult.failed(String.join(", ", validation.getErrors()));
+        return toolExecutor.execute(manifest, input);
+    }
+
+    public RunResult runPipeline(String name, JsonNode input) {
+        var manifest = artifactRepository.loadPipeline(name);
+        var validation = manifestValidator.validatePipeline(manifest);
+        if (!validation.isValid()) return RunResult.failed(String.join(", ", validation.getErrors()));
+        return pipelineExecutor.execute(manifest, input);
+    }
+
+    public List<String> listAgents() { return artifactRepository.listAgents(); }
+    public List<String> listTools() { return artifactRepository.listTools(); }
+    public List<String> listPipelines() { return artifactRepository.listPipelines(); }
+}

--- a/src/main/java/org/hubbers/artifact/ArtifactRepository.java
+++ b/src/main/java/org/hubbers/artifact/ArtifactRepository.java
@@ -1,0 +1,17 @@
+package org.hubbers.artifact;
+
+import org.hubbers.manifest.agent.AgentManifest;
+import org.hubbers.manifest.pipeline.PipelineManifest;
+import org.hubbers.manifest.tool.ToolManifest;
+
+import java.util.List;
+
+public interface ArtifactRepository {
+    List<String> listAgents();
+    List<String> listTools();
+    List<String> listPipelines();
+
+    AgentManifest loadAgent(String name);
+    ToolManifest loadTool(String name);
+    PipelineManifest loadPipeline(String name);
+}

--- a/src/main/java/org/hubbers/artifact/ArtifactScanner.java
+++ b/src/main/java/org/hubbers/artifact/ArtifactScanner.java
@@ -1,0 +1,28 @@
+package org.hubbers.artifact;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class ArtifactScanner {
+
+    public List<String> listManifestNames(Path root, String folder, String manifestName) {
+        Path base = root.resolve(folder);
+        if (!Files.exists(base)) {
+            return List.of();
+        }
+        try (Stream<Path> paths = Files.list(base)) {
+            return paths
+                    .filter(Files::isDirectory)
+                    .filter(p -> Files.exists(p.resolve(manifestName)))
+                    .map(p -> p.getFileName().toString())
+                    .sorted(Comparator.naturalOrder())
+                    .toList();
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot scan artifacts in " + base, e);
+        }
+    }
+}

--- a/src/main/java/org/hubbers/artifact/LocalArtifactRepository.java
+++ b/src/main/java/org/hubbers/artifact/LocalArtifactRepository.java
@@ -1,0 +1,59 @@
+package org.hubbers.artifact;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hubbers.manifest.agent.AgentManifest;
+import org.hubbers.manifest.pipeline.PipelineManifest;
+import org.hubbers.manifest.tool.ToolManifest;
+import org.hubbers.util.JacksonFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class LocalArtifactRepository implements ArtifactRepository {
+    private final Path repoRoot;
+    private final ArtifactScanner scanner;
+    private final ObjectMapper yamlMapper = JacksonFactory.yamlMapper();
+
+    public LocalArtifactRepository(Path repoRoot, ArtifactScanner scanner) {
+        this.repoRoot = repoRoot;
+        this.scanner = scanner;
+    }
+
+    @Override
+    public java.util.List<String> listAgents() {
+        return scanner.listManifestNames(repoRoot, "agents", "agent.yaml");
+    }
+
+    @Override
+    public java.util.List<String> listTools() {
+        return scanner.listManifestNames(repoRoot, "tools", "tool.yaml");
+    }
+
+    @Override
+    public java.util.List<String> listPipelines() {
+        return scanner.listManifestNames(repoRoot, "pipelines", "pipeline.yaml");
+    }
+
+    @Override
+    public AgentManifest loadAgent(String name) {
+        return read(repoRoot.resolve("agents").resolve(name).resolve("agent.yaml"), AgentManifest.class);
+    }
+
+    @Override
+    public ToolManifest loadTool(String name) {
+        return read(repoRoot.resolve("tools").resolve(name).resolve("tool.yaml"), ToolManifest.class);
+    }
+
+    @Override
+    public PipelineManifest loadPipeline(String name) {
+        return read(repoRoot.resolve("pipelines").resolve(name).resolve("pipeline.yaml"), PipelineManifest.class);
+    }
+
+    private <T> T read(Path path, Class<T> type) {
+        try {
+            return yamlMapper.readValue(path.toFile(), type);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot read manifest " + path, e);
+        }
+    }
+}

--- a/src/main/java/org/hubbers/cli/HubbersCommand.java
+++ b/src/main/java/org/hubbers/cli/HubbersCommand.java
@@ -1,0 +1,126 @@
+package org.hubbers.cli;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hubbers.app.RuntimeFacade;
+import org.hubbers.execution.ExecutionStatus;
+import org.hubbers.execution.RunResult;
+import org.hubbers.util.JacksonFactory;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "hubbers", mixinStandardHelpOptions = true,
+        subcommands = {HubbersCommand.ListCommand.class, HubbersCommand.AgentCommand.class,
+                HubbersCommand.ToolCommand.class, HubbersCommand.PipelineCommand.class})
+public class HubbersCommand implements Callable<Integer> {
+    final RuntimeFacade runtimeFacade;
+
+    public HubbersCommand(RuntimeFacade runtimeFacade) {
+        this.runtimeFacade = runtimeFacade;
+    }
+
+    @Override
+    public Integer call() {
+        CommandLine.usage(this, System.out);
+        return 0;
+    }
+
+    @CommandLine.Command(name = "list", subcommands = {ListAgents.class, ListTools.class, ListPipelines.class})
+    static class ListCommand implements Callable<Integer> {
+        @CommandLine.ParentCommand HubbersCommand root;
+        @Override public Integer call() { CommandLine.usage(this, System.out); return 0; }
+    }
+
+    @CommandLine.Command(name = "agents")
+    static class ListAgents implements Callable<Integer> {
+        @CommandLine.ParentCommand ListCommand parent;
+        @Override public Integer call() { return printList(parent.root.runtimeFacade.listAgents()); }
+    }
+
+    @CommandLine.Command(name = "tools")
+    static class ListTools implements Callable<Integer> {
+        @CommandLine.ParentCommand ListCommand parent;
+        @Override public Integer call() { return printList(parent.root.runtimeFacade.listTools()); }
+    }
+
+    @CommandLine.Command(name = "pipelines")
+    static class ListPipelines implements Callable<Integer> {
+        @CommandLine.ParentCommand ListCommand parent;
+        @Override public Integer call() { return printList(parent.root.runtimeFacade.listPipelines()); }
+    }
+
+    @CommandLine.Command(name = "agent", subcommands = AgentRun.class)
+    static class AgentCommand implements Callable<Integer> {
+        @CommandLine.ParentCommand HubbersCommand root;
+        @Override public Integer call() { return 0; }
+    }
+
+    @CommandLine.Command(name = "run")
+    static class AgentRun implements Callable<Integer> {
+        @CommandLine.ParentCommand AgentCommand parent;
+        @CommandLine.Parameters(index = "0") String name;
+        @CommandLine.Option(names = "--input", required = true) File input;
+        @Override public Integer call() { return run(parent.root.runtimeFacade, name, input, Mode.AGENT); }
+    }
+
+    @CommandLine.Command(name = "tool", subcommands = ToolRun.class)
+    static class ToolCommand implements Callable<Integer> {
+        @CommandLine.ParentCommand HubbersCommand root;
+        @Override public Integer call() { return 0; }
+    }
+
+    @CommandLine.Command(name = "run")
+    static class ToolRun implements Callable<Integer> {
+        @CommandLine.ParentCommand ToolCommand parent;
+        @CommandLine.Parameters(index = "0") String name;
+        @CommandLine.Option(names = "--input", required = true) File input;
+        @Override public Integer call() { return run(parent.root.runtimeFacade, name, input, Mode.TOOL); }
+    }
+
+    @CommandLine.Command(name = "pipeline", subcommands = PipelineRun.class)
+    static class PipelineCommand implements Callable<Integer> {
+        @CommandLine.ParentCommand HubbersCommand root;
+        @Override public Integer call() { return 0; }
+    }
+
+    @CommandLine.Command(name = "run")
+    static class PipelineRun implements Callable<Integer> {
+        @CommandLine.ParentCommand PipelineCommand parent;
+        @CommandLine.Parameters(index = "0") String name;
+        @CommandLine.Option(names = "--input", required = true) File input;
+        @Override public Integer call() { return run(parent.root.runtimeFacade, name, input, Mode.PIPELINE); }
+    }
+
+    private enum Mode { AGENT, TOOL, PIPELINE }
+
+    private static Integer run(RuntimeFacade facade, String name, File inputFile, Mode mode) {
+        ObjectMapper mapper = JacksonFactory.jsonMapper();
+        try {
+            JsonNode input = mapper.readTree(Files.readString(inputFile.toPath()));
+            RunResult result = switch (mode) {
+                case AGENT -> facade.runAgent(name, input);
+                case TOOL -> facade.runTool(name, input);
+                case PIPELINE -> facade.runPipeline(name, input);
+            };
+            if (result.getStatus() == ExecutionStatus.SUCCESS) {
+                System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(result.getOutput()));
+                return 0;
+            }
+            System.err.println(result.getError());
+            return 1;
+        } catch (IOException e) {
+            System.err.println("Input read/parse failed: " + e.getMessage());
+            return 1;
+        }
+    }
+
+    private static Integer printList(List<String> values) {
+        values.forEach(System.out::println);
+        return 0;
+    }
+}

--- a/src/main/java/org/hubbers/config/AppConfig.java
+++ b/src/main/java/org/hubbers/config/AppConfig.java
@@ -1,0 +1,22 @@
+package org.hubbers.config;
+
+public class AppConfig {
+    private String repoRoot;
+    private OpenAiConfig openai;
+
+    public String getRepoRoot() {
+        return repoRoot;
+    }
+
+    public void setRepoRoot(String repoRoot) {
+        this.repoRoot = repoRoot;
+    }
+
+    public OpenAiConfig getOpenai() {
+        return openai;
+    }
+
+    public void setOpenai(OpenAiConfig openai) {
+        this.openai = openai;
+    }
+}

--- a/src/main/java/org/hubbers/config/ConfigLoader.java
+++ b/src/main/java/org/hubbers/config/ConfigLoader.java
@@ -1,0 +1,43 @@
+package org.hubbers.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hubbers.util.JacksonFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class ConfigLoader {
+    private final ObjectMapper yamlMapper = JacksonFactory.yamlMapper();
+
+    public AppConfig load() {
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream("application.yaml")) {
+            if (is == null) {
+                throw new IllegalStateException("application.yaml not found");
+            }
+            AppConfig appConfig = yamlMapper.readValue(is, AppConfig.class);
+            resolveEnv(appConfig);
+            return appConfig;
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot load application config", e);
+        }
+    }
+
+    private void resolveEnv(AppConfig appConfig) {
+        if (appConfig.getOpenai() == null) {
+            return;
+        }
+        OpenAiConfig openAi = appConfig.getOpenai();
+        openAi.setApiKey(resolveValue(openAi.getApiKey()));
+    }
+
+    private String resolveValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        if (value.startsWith("${") && value.endsWith("}")) {
+            String envName = value.substring(2, value.length() - 1);
+            return System.getenv(envName);
+        }
+        return value;
+    }
+}

--- a/src/main/java/org/hubbers/config/OpenAiConfig.java
+++ b/src/main/java/org/hubbers/config/OpenAiConfig.java
@@ -1,0 +1,31 @@
+package org.hubbers.config;
+
+public class OpenAiConfig {
+    private String apiKey;
+    private String baseUrl;
+    private String defaultModel;
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getDefaultModel() {
+        return defaultModel;
+    }
+
+    public void setDefaultModel(String defaultModel) {
+        this.defaultModel = defaultModel;
+    }
+}

--- a/src/main/java/org/hubbers/execution/ExecutionMetadata.java
+++ b/src/main/java/org/hubbers/execution/ExecutionMetadata.java
@@ -1,0 +1,14 @@
+package org.hubbers.execution;
+
+public class ExecutionMetadata {
+    private long startedAt;
+    private long endedAt;
+    private String details;
+
+    public long getStartedAt() { return startedAt; }
+    public void setStartedAt(long startedAt) { this.startedAt = startedAt; }
+    public long getEndedAt() { return endedAt; }
+    public void setEndedAt(long endedAt) { this.endedAt = endedAt; }
+    public String getDetails() { return details; }
+    public void setDetails(String details) { this.details = details; }
+}

--- a/src/main/java/org/hubbers/execution/ExecutionStatus.java
+++ b/src/main/java/org/hubbers/execution/ExecutionStatus.java
@@ -1,0 +1,6 @@
+package org.hubbers.execution;
+
+public enum ExecutionStatus {
+    SUCCESS,
+    FAILED
+}

--- a/src/main/java/org/hubbers/execution/RunResult.java
+++ b/src/main/java/org/hubbers/execution/RunResult.java
@@ -1,0 +1,33 @@
+package org.hubbers.execution;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class RunResult {
+    private ExecutionStatus status;
+    private JsonNode output;
+    private String error;
+    private ExecutionMetadata metadata;
+
+    public static RunResult success(JsonNode output) {
+        RunResult result = new RunResult();
+        result.setStatus(ExecutionStatus.SUCCESS);
+        result.setOutput(output);
+        return result;
+    }
+
+    public static RunResult failed(String error) {
+        RunResult result = new RunResult();
+        result.setStatus(ExecutionStatus.FAILED);
+        result.setError(error);
+        return result;
+    }
+
+    public ExecutionStatus getStatus() { return status; }
+    public void setStatus(ExecutionStatus status) { this.status = status; }
+    public JsonNode getOutput() { return output; }
+    public void setOutput(JsonNode output) { this.output = output; }
+    public String getError() { return error; }
+    public void setError(String error) { this.error = error; }
+    public ExecutionMetadata getMetadata() { return metadata; }
+    public void setMetadata(ExecutionMetadata metadata) { this.metadata = metadata; }
+}

--- a/src/main/java/org/hubbers/manifest/agent/AgentManifest.java
+++ b/src/main/java/org/hubbers/manifest/agent/AgentManifest.java
@@ -1,0 +1,28 @@
+package org.hubbers.manifest.agent;
+
+import org.hubbers.manifest.common.Metadata;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AgentManifest {
+    private Metadata agent;
+    private ModelConfig model;
+    private Instructions instructions;
+    private InputDefinition input;
+    private OutputDefinition output;
+    private List<ToolReference> tools = new ArrayList<>();
+
+    public Metadata getAgent() { return agent; }
+    public void setAgent(Metadata agent) { this.agent = agent; }
+    public ModelConfig getModel() { return model; }
+    public void setModel(ModelConfig model) { this.model = model; }
+    public Instructions getInstructions() { return instructions; }
+    public void setInstructions(Instructions instructions) { this.instructions = instructions; }
+    public InputDefinition getInput() { return input; }
+    public void setInput(InputDefinition input) { this.input = input; }
+    public OutputDefinition getOutput() { return output; }
+    public void setOutput(OutputDefinition output) { this.output = output; }
+    public List<ToolReference> getTools() { return tools; }
+    public void setTools(List<ToolReference> tools) { this.tools = tools; }
+}

--- a/src/main/java/org/hubbers/manifest/agent/InputDefinition.java
+++ b/src/main/java/org/hubbers/manifest/agent/InputDefinition.java
@@ -1,0 +1,10 @@
+package org.hubbers.manifest.agent;
+
+import org.hubbers.manifest.common.SchemaDefinition;
+
+public class InputDefinition {
+    private SchemaDefinition schema;
+
+    public SchemaDefinition getSchema() { return schema; }
+    public void setSchema(SchemaDefinition schema) { this.schema = schema; }
+}

--- a/src/main/java/org/hubbers/manifest/agent/Instructions.java
+++ b/src/main/java/org/hubbers/manifest/agent/Instructions.java
@@ -1,0 +1,11 @@
+package org.hubbers.manifest.agent;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Instructions {
+    @JsonProperty("system_prompt")
+    private String systemPrompt;
+
+    public String getSystemPrompt() { return systemPrompt; }
+    public void setSystemPrompt(String systemPrompt) { this.systemPrompt = systemPrompt; }
+}

--- a/src/main/java/org/hubbers/manifest/agent/ModelConfig.java
+++ b/src/main/java/org/hubbers/manifest/agent/ModelConfig.java
@@ -1,0 +1,14 @@
+package org.hubbers.manifest.agent;
+
+public class ModelConfig {
+    private String provider;
+    private String name;
+    private Double temperature;
+
+    public String getProvider() { return provider; }
+    public void setProvider(String provider) { this.provider = provider; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public Double getTemperature() { return temperature; }
+    public void setTemperature(Double temperature) { this.temperature = temperature; }
+}

--- a/src/main/java/org/hubbers/manifest/agent/OutputDefinition.java
+++ b/src/main/java/org/hubbers/manifest/agent/OutputDefinition.java
@@ -1,0 +1,10 @@
+package org.hubbers.manifest.agent;
+
+import org.hubbers.manifest.common.SchemaDefinition;
+
+public class OutputDefinition {
+    private SchemaDefinition schema;
+
+    public SchemaDefinition getSchema() { return schema; }
+    public void setSchema(SchemaDefinition schema) { this.schema = schema; }
+}

--- a/src/main/java/org/hubbers/manifest/agent/ToolReference.java
+++ b/src/main/java/org/hubbers/manifest/agent/ToolReference.java
@@ -1,0 +1,8 @@
+package org.hubbers.manifest.agent;
+
+public class ToolReference {
+    private String name;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+}

--- a/src/main/java/org/hubbers/manifest/common/Metadata.java
+++ b/src/main/java/org/hubbers/manifest/common/Metadata.java
@@ -1,0 +1,14 @@
+package org.hubbers.manifest.common;
+
+public class Metadata {
+    private String name;
+    private String version;
+    private String description;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getVersion() { return version; }
+    public void setVersion(String version) { this.version = version; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+}

--- a/src/main/java/org/hubbers/manifest/common/PropertyDefinition.java
+++ b/src/main/java/org/hubbers/manifest/common/PropertyDefinition.java
@@ -1,0 +1,11 @@
+package org.hubbers.manifest.common;
+
+public class PropertyDefinition {
+    private String type;
+    private boolean required;
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+    public boolean isRequired() { return required; }
+    public void setRequired(boolean required) { this.required = required; }
+}

--- a/src/main/java/org/hubbers/manifest/common/SchemaDefinition.java
+++ b/src/main/java/org/hubbers/manifest/common/SchemaDefinition.java
@@ -1,0 +1,14 @@
+package org.hubbers.manifest.common;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class SchemaDefinition {
+    private String type;
+    private Map<String, PropertyDefinition> properties = new LinkedHashMap<>();
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+    public Map<String, PropertyDefinition> getProperties() { return properties; }
+    public void setProperties(Map<String, PropertyDefinition> properties) { this.properties = properties; }
+}

--- a/src/main/java/org/hubbers/manifest/pipeline/PipelineManifest.java
+++ b/src/main/java/org/hubbers/manifest/pipeline/PipelineManifest.java
@@ -1,0 +1,16 @@
+package org.hubbers.manifest.pipeline;
+
+import org.hubbers.manifest.common.Metadata;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PipelineManifest {
+    private Metadata pipeline;
+    private List<PipelineStep> steps = new ArrayList<>();
+
+    public Metadata getPipeline() { return pipeline; }
+    public void setPipeline(Metadata pipeline) { this.pipeline = pipeline; }
+    public List<PipelineStep> getSteps() { return steps; }
+    public void setSteps(List<PipelineStep> steps) { this.steps = steps; }
+}

--- a/src/main/java/org/hubbers/manifest/pipeline/PipelineStep.java
+++ b/src/main/java/org/hubbers/manifest/pipeline/PipelineStep.java
@@ -1,0 +1,22 @@
+package org.hubbers.manifest.pipeline;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public class PipelineStep {
+    private String id;
+    private String agent;
+    private String tool;
+    @JsonProperty("input_mapping")
+    private Map<String, String> inputMapping;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getAgent() { return agent; }
+    public void setAgent(String agent) { this.agent = agent; }
+    public String getTool() { return tool; }
+    public void setTool(String tool) { this.tool = tool; }
+    public Map<String, String> getInputMapping() { return inputMapping; }
+    public void setInputMapping(Map<String, String> inputMapping) { this.inputMapping = inputMapping; }
+}

--- a/src/main/java/org/hubbers/manifest/tool/ToolManifest.java
+++ b/src/main/java/org/hubbers/manifest/tool/ToolManifest.java
@@ -1,0 +1,27 @@
+package org.hubbers.manifest.tool;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hubbers.manifest.agent.InputDefinition;
+import org.hubbers.manifest.agent.OutputDefinition;
+import org.hubbers.manifest.common.Metadata;
+
+import java.util.Map;
+
+public class ToolManifest {
+    private Metadata tool;
+    private String type;
+    private Map<String, Object> config;
+    private InputDefinition input;
+    private OutputDefinition output;
+
+    public Metadata getTool() { return tool; }
+    public void setTool(Metadata tool) { this.tool = tool; }
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+    public Map<String, Object> getConfig() { return config; }
+    public void setConfig(Map<String, Object> config) { this.config = config; }
+    public InputDefinition getInput() { return input; }
+    public void setInput(InputDefinition input) { this.input = input; }
+    public OutputDefinition getOutput() { return output; }
+    public void setOutput(OutputDefinition output) { this.output = output; }
+}

--- a/src/main/java/org/hubbers/model/ModelProvider.java
+++ b/src/main/java/org/hubbers/model/ModelProvider.java
@@ -1,0 +1,6 @@
+package org.hubbers.model;
+
+public interface ModelProvider {
+    String providerName();
+    ModelResponse generate(ModelRequest request);
+}

--- a/src/main/java/org/hubbers/model/ModelProviderRegistry.java
+++ b/src/main/java/org/hubbers/model/ModelProviderRegistry.java
@@ -1,0 +1,23 @@
+package org.hubbers.model;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ModelProviderRegistry {
+    private final Map<String, ModelProvider> providers = new HashMap<>();
+
+    public ModelProviderRegistry(List<ModelProvider> providers) {
+        for (ModelProvider provider : providers) {
+            this.providers.put(provider.providerName(), provider);
+        }
+    }
+
+    public ModelProvider get(String providerName) {
+        ModelProvider provider = providers.get(providerName);
+        if (provider == null) {
+            throw new IllegalArgumentException("Model provider not found: " + providerName);
+        }
+        return provider;
+    }
+}

--- a/src/main/java/org/hubbers/model/ModelRequest.java
+++ b/src/main/java/org/hubbers/model/ModelRequest.java
@@ -1,0 +1,17 @@
+package org.hubbers.model;
+
+public class ModelRequest {
+    private String systemPrompt;
+    private String userPrompt;
+    private String model;
+    private Double temperature;
+
+    public String getSystemPrompt() { return systemPrompt; }
+    public void setSystemPrompt(String systemPrompt) { this.systemPrompt = systemPrompt; }
+    public String getUserPrompt() { return userPrompt; }
+    public void setUserPrompt(String userPrompt) { this.userPrompt = userPrompt; }
+    public String getModel() { return model; }
+    public void setModel(String model) { this.model = model; }
+    public Double getTemperature() { return temperature; }
+    public void setTemperature(Double temperature) { this.temperature = temperature; }
+}

--- a/src/main/java/org/hubbers/model/ModelResponse.java
+++ b/src/main/java/org/hubbers/model/ModelResponse.java
@@ -1,0 +1,14 @@
+package org.hubbers.model;
+
+public class ModelResponse {
+    private String content;
+    private String model;
+    private long latencyMs;
+
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+    public String getModel() { return model; }
+    public void setModel(String model) { this.model = model; }
+    public long getLatencyMs() { return latencyMs; }
+    public void setLatencyMs(long latencyMs) { this.latencyMs = latencyMs; }
+}

--- a/src/main/java/org/hubbers/model/OpenAiModelProvider.java
+++ b/src/main/java/org/hubbers/model/OpenAiModelProvider.java
@@ -1,0 +1,72 @@
+package org.hubbers.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.hubbers.config.OpenAiConfig;
+import org.hubbers.util.JacksonFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class OpenAiModelProvider implements ModelProvider {
+    private final HttpClient httpClient;
+    private final OpenAiConfig config;
+    private final ObjectMapper mapper = JacksonFactory.jsonMapper();
+
+    public OpenAiModelProvider(HttpClient httpClient, OpenAiConfig config) {
+        this.httpClient = httpClient;
+        this.config = config;
+    }
+
+    @Override
+    public String providerName() {
+        return "openai";
+    }
+
+    @Override
+    public ModelResponse generate(ModelRequest request) {
+        if (config.getApiKey() == null || config.getApiKey().isBlank()) {
+            throw new IllegalStateException("OPENAI_API_KEY is missing");
+        }
+        long start = System.currentTimeMillis();
+        try {
+            ObjectNode payload = mapper.createObjectNode();
+            payload.put("model", request.getModel() != null ? request.getModel() : config.getDefaultModel());
+            if (request.getTemperature() != null) {
+                payload.put("temperature", request.getTemperature());
+            }
+            ArrayNode messages = payload.putArray("messages");
+            messages.addObject().put("role", "system").put("content", request.getSystemPrompt());
+            messages.addObject().put("role", "user").put("content", request.getUserPrompt());
+
+            HttpRequest httpRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(config.getBaseUrl() + "/chat/completions"))
+                    .header("Authorization", "Bearer " + config.getApiKey())
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(payload)))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() >= 400) {
+                throw new IllegalStateException("OpenAI error " + response.statusCode() + ": " + response.body());
+            }
+
+            JsonNode root = mapper.readTree(response.body());
+            String content = root.path("choices").path(0).path("message").path("content").asText();
+
+            ModelResponse modelResponse = new ModelResponse();
+            modelResponse.setContent(content);
+            modelResponse.setModel(root.path("model").asText(payload.path("model").asText()));
+            modelResponse.setLatencyMs(System.currentTimeMillis() - start);
+            return modelResponse;
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("OpenAI call failed", e);
+        }
+    }
+}

--- a/src/main/java/org/hubbers/pipeline/InputMapper.java
+++ b/src/main/java/org/hubbers/pipeline/InputMapper.java
@@ -1,0 +1,48 @@
+package org.hubbers.pipeline;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.Map;
+
+public class InputMapper {
+    private final ObjectMapper mapper;
+
+    public InputMapper(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public JsonNode map(JsonNode initialInput, Map<String, String> mapping, PipelineState state) {
+        if (mapping == null || mapping.isEmpty()) {
+            return initialInput;
+        }
+        ObjectNode output = mapper.createObjectNode();
+        for (Map.Entry<String, String> entry : mapping.entrySet()) {
+            String targetField = entry.getKey();
+            String sourceExpr = entry.getValue();
+            JsonNode resolved = resolveExpression(sourceExpr, state);
+            output.set(targetField, resolved == null ? mapper.nullNode() : resolved);
+        }
+        return output;
+    }
+
+    private JsonNode resolveExpression(String expression, PipelineState state) {
+        if (expression == null || !expression.startsWith("${") || !expression.endsWith("}")) {
+            return mapper.valueToTree(expression);
+        }
+        String path = expression.substring(2, expression.length() - 1);
+        String[] parts = path.split("\\.");
+        if (parts.length < 4 || !"steps".equals(parts[0]) || !"output".equals(parts[2])) {
+            return mapper.nullNode();
+        }
+        JsonNode current = state.getStepOutput(parts[1]);
+        for (int i = 3; i < parts.length; i++) {
+            if (current == null) {
+                return mapper.nullNode();
+            }
+            current = current.get(parts[i]);
+        }
+        return current;
+    }
+}

--- a/src/main/java/org/hubbers/pipeline/PipelineExecutor.java
+++ b/src/main/java/org/hubbers/pipeline/PipelineExecutor.java
@@ -1,0 +1,45 @@
+package org.hubbers.pipeline;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.hubbers.agent.AgentExecutor;
+import org.hubbers.artifact.ArtifactRepository;
+import org.hubbers.execution.RunResult;
+import org.hubbers.manifest.pipeline.PipelineManifest;
+import org.hubbers.manifest.pipeline.PipelineStep;
+import org.hubbers.tool.ToolExecutor;
+
+public class PipelineExecutor {
+    private final ArtifactRepository artifactRepository;
+    private final AgentExecutor agentExecutor;
+    private final ToolExecutor toolExecutor;
+    private final InputMapper inputMapper;
+
+    public PipelineExecutor(ArtifactRepository artifactRepository,
+                            AgentExecutor agentExecutor,
+                            ToolExecutor toolExecutor,
+                            InputMapper inputMapper) {
+        this.artifactRepository = artifactRepository;
+        this.agentExecutor = agentExecutor;
+        this.toolExecutor = toolExecutor;
+        this.inputMapper = inputMapper;
+    }
+
+    public RunResult execute(PipelineManifest manifest, JsonNode input) {
+        PipelineState state = new PipelineState();
+        for (PipelineStep step : manifest.getSteps()) {
+            JsonNode stepInput = inputMapper.map(input, step.getInputMapping(), state);
+            RunResult stepResult;
+            if (step.getTool() != null && !step.getTool().isBlank()) {
+                stepResult = toolExecutor.execute(artifactRepository.loadTool(step.getTool()), stepInput);
+            } else {
+                stepResult = agentExecutor.execute(artifactRepository.loadAgent(step.getAgent()), stepInput);
+            }
+            if (stepResult.getStatus() != org.hubbers.execution.ExecutionStatus.SUCCESS) {
+                return stepResult;
+            }
+            state.putStepOutput(step.getId(), stepResult.getOutput());
+        }
+        String lastStepId = manifest.getSteps().get(manifest.getSteps().size() - 1).getId();
+        return RunResult.success(state.getStepOutput(lastStepId));
+    }
+}

--- a/src/main/java/org/hubbers/pipeline/PipelineState.java
+++ b/src/main/java/org/hubbers/pipeline/PipelineState.java
@@ -1,0 +1,18 @@
+package org.hubbers.pipeline;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PipelineState {
+    private final Map<String, JsonNode> stepOutputs = new HashMap<>();
+
+    public void putStepOutput(String stepId, JsonNode output) {
+        stepOutputs.put(stepId, output);
+    }
+
+    public JsonNode getStepOutput(String stepId) {
+        return stepOutputs.get(stepId);
+    }
+}

--- a/src/main/java/org/hubbers/storage/package-info.java
+++ b/src/main/java/org/hubbers/storage/package-info.java
@@ -1,0 +1,1 @@
+package org.hubbers.storage;

--- a/src/main/java/org/hubbers/tool/DockerToolDriver.java
+++ b/src/main/java/org/hubbers/tool/DockerToolDriver.java
@@ -1,0 +1,68 @@
+package org.hubbers.tool;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hubbers.manifest.tool.ToolManifest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public class DockerToolDriver implements ToolDriver {
+    private final ObjectMapper mapper;
+
+    public DockerToolDriver(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public String type() {
+        return "docker";
+    }
+
+    @Override
+    public JsonNode execute(ToolManifest manifest, JsonNode input) {
+        String image = manifest.getConfig().get("image").toString();
+        Path tmpDir = null;
+        try {
+            tmpDir = Files.createTempDirectory("hubbers-tool-");
+            Path inputPath = tmpDir.resolve("input.json");
+            Path outputPath = tmpDir.resolve("output.json");
+            mapper.writeValue(inputPath.toFile(), input);
+
+            List<String> cmd = List.of(
+                    "docker", "run", "--rm",
+                    "-v", tmpDir.toAbsolutePath() + ":/workspace",
+                    image
+            );
+            Process process = new ProcessBuilder(cmd)
+                    .redirectErrorStream(true)
+                    .start();
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                String log = new String(process.getInputStream().readAllBytes());
+                throw new IllegalStateException("Docker tool failed with code " + exitCode + ": " + log);
+            }
+            if (!Files.exists(outputPath)) {
+                throw new IllegalStateException("Docker tool did not produce /workspace/output.json");
+            }
+            return mapper.readTree(outputPath.toFile());
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Docker tool execution failed", e);
+        } finally {
+            if (tmpDir != null) {
+                try (var s = Files.walk(tmpDir)) {
+                    s.sorted((a, b) -> b.compareTo(a)).forEach(path -> {
+                        try {
+                            Files.deleteIfExists(path);
+                        } catch (IOException ignored) {
+                        }
+                    });
+                } catch (IOException ignored) {
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/hubbers/tool/HttpToolDriver.java
+++ b/src/main/java/org/hubbers/tool/HttpToolDriver.java
@@ -1,0 +1,59 @@
+package org.hubbers.tool;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hubbers.manifest.tool.ToolManifest;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class HttpToolDriver implements ToolDriver {
+    private final HttpClient httpClient;
+    private final ObjectMapper mapper;
+
+    public HttpToolDriver(HttpClient httpClient, ObjectMapper mapper) {
+        this.httpClient = httpClient;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public String type() {
+        return "http";
+    }
+
+    @Override
+    public JsonNode execute(ToolManifest manifest, JsonNode input) {
+        String baseUrl = asString(manifest, "base_url");
+        String method = manifest.getConfig().getOrDefault("method", "POST").toString();
+        try {
+            HttpRequest.Builder builder = HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl))
+                    .header("Content-Type", "application/json");
+            String payload = mapper.writeValueAsString(input);
+            if ("GET".equalsIgnoreCase(method)) {
+                builder.GET();
+            } else {
+                builder.method(method.toUpperCase(), HttpRequest.BodyPublishers.ofString(payload));
+            }
+            HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() >= 400) {
+                throw new IllegalStateException("HTTP tool failed: " + response.statusCode() + " - " + response.body());
+            }
+            return mapper.readTree(response.body());
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("HTTP tool failed", e);
+        }
+    }
+
+    private String asString(ToolManifest manifest, String key) {
+        Object value = manifest.getConfig().get(key);
+        if (value == null) {
+            throw new IllegalArgumentException("Missing config key: " + key);
+        }
+        return value.toString();
+    }
+}

--- a/src/main/java/org/hubbers/tool/ToolDriver.java
+++ b/src/main/java/org/hubbers/tool/ToolDriver.java
@@ -1,0 +1,9 @@
+package org.hubbers.tool;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.hubbers.manifest.tool.ToolManifest;
+
+public interface ToolDriver {
+    String type();
+    JsonNode execute(ToolManifest manifest, JsonNode input);
+}

--- a/src/main/java/org/hubbers/tool/ToolExecutor.java
+++ b/src/main/java/org/hubbers/tool/ToolExecutor.java
@@ -1,0 +1,40 @@
+package org.hubbers.tool;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.hubbers.execution.RunResult;
+import org.hubbers.manifest.tool.ToolManifest;
+import org.hubbers.validation.SchemaValidator;
+import org.hubbers.validation.ValidationResult;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ToolExecutor {
+    private final Map<String, ToolDriver> drivers = new HashMap<>();
+    private final SchemaValidator schemaValidator;
+
+    public ToolExecutor(List<ToolDriver> drivers, SchemaValidator schemaValidator) {
+        for (ToolDriver driver : drivers) {
+            this.drivers.put(driver.type(), driver);
+        }
+        this.schemaValidator = schemaValidator;
+    }
+
+    public RunResult execute(ToolManifest manifest, JsonNode input) {
+        ValidationResult inputValidation = schemaValidator.validate(input, manifest.getInput().getSchema());
+        if (!inputValidation.isValid()) {
+            return RunResult.failed(String.join(", ", inputValidation.getErrors()));
+        }
+        ToolDriver driver = drivers.get(manifest.getType());
+        if (driver == null) {
+            return RunResult.failed("Unsupported tool type: " + manifest.getType());
+        }
+        JsonNode output = driver.execute(manifest, input);
+        ValidationResult outputValidation = schemaValidator.validate(output, manifest.getOutput().getSchema());
+        if (!outputValidation.isValid()) {
+            return RunResult.failed(String.join(", ", outputValidation.getErrors()));
+        }
+        return RunResult.success(output);
+    }
+}

--- a/src/main/java/org/hubbers/util/JacksonFactory.java
+++ b/src/main/java/org/hubbers/util/JacksonFactory.java
@@ -1,0 +1,24 @@
+package org.hubbers.util;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+public final class JacksonFactory {
+    private JacksonFactory() {
+    }
+
+    public static ObjectMapper jsonMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return mapper;
+    }
+
+    public static ObjectMapper yamlMapper() {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.findAndRegisterModules();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return mapper;
+    }
+}

--- a/src/main/java/org/hubbers/validation/ManifestValidator.java
+++ b/src/main/java/org/hubbers/validation/ManifestValidator.java
@@ -1,0 +1,55 @@
+package org.hubbers.validation;
+
+import org.hubbers.manifest.agent.AgentManifest;
+import org.hubbers.manifest.pipeline.PipelineManifest;
+import org.hubbers.manifest.pipeline.PipelineStep;
+import org.hubbers.manifest.tool.ToolManifest;
+
+public class ManifestValidator {
+
+    public ValidationResult validateAgent(AgentManifest manifest) {
+        ValidationResult result = ValidationResult.ok();
+        if (manifest == null || manifest.getAgent() == null) {
+            result.addError("Agent metadata missing");
+            return result;
+        }
+        if (manifest.getModel() == null || manifest.getModel().getProvider() == null) {
+            result.addError("Agent model provider missing");
+        }
+        if (manifest.getInstructions() == null || manifest.getInstructions().getSystemPrompt() == null) {
+            result.addError("Agent instructions missing");
+        }
+        return result;
+    }
+
+    public ValidationResult validateTool(ToolManifest manifest) {
+        ValidationResult result = ValidationResult.ok();
+        if (manifest == null || manifest.getTool() == null) {
+            result.addError("Tool metadata missing");
+            return result;
+        }
+        if (!"http".equals(manifest.getType()) && !"docker".equals(manifest.getType())) {
+            result.addError("Invalid tool type: " + manifest.getType());
+        }
+        if (manifest.getConfig() == null || manifest.getConfig().isEmpty()) {
+            result.addError("Tool config missing");
+        }
+        return result;
+    }
+
+    public ValidationResult validatePipeline(PipelineManifest manifest) {
+        ValidationResult result = ValidationResult.ok();
+        if (manifest == null || manifest.getPipeline() == null) {
+            result.addError("Pipeline metadata missing");
+            return result;
+        }
+        for (PipelineStep step : manifest.getSteps()) {
+            boolean hasAgent = step.getAgent() != null && !step.getAgent().isBlank();
+            boolean hasTool = step.getTool() != null && !step.getTool().isBlank();
+            if (hasAgent == hasTool) {
+                result.addError("Step " + step.getId() + " must contain agent XOR tool");
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/hubbers/validation/SchemaValidator.java
+++ b/src/main/java/org/hubbers/validation/SchemaValidator.java
@@ -1,0 +1,41 @@
+package org.hubbers.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.hubbers.manifest.common.PropertyDefinition;
+import org.hubbers.manifest.common.SchemaDefinition;
+
+import java.util.Map;
+
+public class SchemaValidator {
+
+    public ValidationResult validate(JsonNode input, SchemaDefinition schema) {
+        ValidationResult result = ValidationResult.ok();
+        if (schema == null || schema.getProperties() == null) {
+            return result;
+        }
+        for (Map.Entry<String, PropertyDefinition> entry : schema.getProperties().entrySet()) {
+            String key = entry.getKey();
+            PropertyDefinition property = entry.getValue();
+            JsonNode value = input.get(key);
+            if (property.isRequired() && (value == null || value.isNull())) {
+                result.addError("Required field missing: " + key);
+                continue;
+            }
+            if (value != null && !value.isNull() && !matchesType(value, property.getType())) {
+                result.addError("Invalid type for field " + key + ", expected: " + property.getType());
+            }
+        }
+        return result;
+    }
+
+    private boolean matchesType(JsonNode value, String type) {
+        if (type == null) return true;
+        return switch (type) {
+            case "string" -> value.isTextual();
+            case "number" -> value.isNumber();
+            case "boolean" -> value.isBoolean();
+            case "object" -> value.isObject();
+            default -> true;
+        };
+    }
+}

--- a/src/main/java/org/hubbers/validation/ValidationResult.java
+++ b/src/main/java/org/hubbers/validation/ValidationResult.java
@@ -1,0 +1,16 @@
+package org.hubbers.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ValidationResult {
+    private final List<String> errors = new ArrayList<>();
+
+    public static ValidationResult ok() {
+        return new ValidationResult();
+    }
+
+    public void addError(String error) { errors.add(error); }
+    public boolean isValid() { return errors.isEmpty(); }
+    public List<String> getErrors() { return errors; }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,6 @@
+repoRoot: ./repo
+
+openai:
+  apiKey: ${OPENAI_API_KEY}
+  baseUrl: https://api.openai.com/v1
+  defaultModel: gpt-4.1-mini

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
### Motivation
- Fornire un prototipo monolitico Java 21 (senza Spring, senza LangChain4j) per il framework Hubbers che esegue agent, tool e pipeline definibili via manifest YAML.
- Usare un approccio modulare e minimale con dependency injection manuale (composition root) e strumenti leggeri (HttpClient, ProcessBuilder, Jackson, picocli) per mantenere il codice semplice ed estendibile.

### Description
- Aggiunta della struttura del progetto e entrypoint `org.hubbers.Main` con composition root in `org.hubbers.app.Bootstrap` e facciata runtime `org.hubbers.app.RuntimeFacade` che espone `runAgent/runTool/runPipeline` e metodi `list*`.
- Implementati i modelli manifest richiesti (`Metadata`, `SchemaDefinition`, `PropertyDefinition`, `AgentManifest` e sue classi correlate, `ToolManifest`, `PipelineManifest`, `PipelineStep`) con mapping Jackson dove necessario (`system_prompt`, `input_mapping`).
- Implementato il layer artifact con `ArtifactRepository`, `ArtifactScanner` e `LocalArtifactRepository` per caricare manifest YAML da `repo/agents`, `repo/tools`, `repo/pipelines` usando Jackson YAML.
- Implementati provider/modello e runtime: `ModelProvider` + `ModelProviderRegistry`, `OpenAiModelProvider` che chiama l’API OpenAI via `HttpClient`, `AgentPromptBuilder` + `AgentExecutor`, `ToolExecutor` con driver `HttpToolDriver` e `DockerToolDriver` (con convenzione `/workspace/input.json` → `/workspace/output.json`), e `PipelineExecutor` con `InputMapper` e `PipelineState` per eseguire step sequenziali.
- Aggiunte validazioni minimali (`ManifestValidator`, `SchemaValidator`, `ValidationResult`) e rappresentazioni di esecuzione (`RunResult`, `ExecutionStatus`, `ExecutionMetadata`).
- Implementata CLI con `picocli` in `org.hubbers.cli.HubbersCommand` per i comandi richiesti (`list agents|tools|pipelines`, `agent/tool/pipeline run <name> --input <file.json>`), stampa JSON formattato e exit code appropriati.
- Aggiunti `application.yaml` e classi di configurazione `AppConfig`, `OpenAiConfig`, `ConfigLoader` (risoluzione variabili d’ambiente per la API key) e `pom.xml` (Java 21, dipendenze richieste, shade plugin) e `logback.xml`.
- Popolati esempi di manifest in `repo/` per `text.summarizer`, `pdf.extract`, `weather.lookup` e pipeline `pdf.summary`.

### Testing
- Tentativo di build: eseguito `mvn -DskipTests package` per verificare che il progetto si compili e venga pacchettizzato; il tentativo fallisce nell’ambiente corrente a causa di un problema di risoluzione plugin Maven (accesso a Maven Central restituisce `403` durante il download di `maven-resources-plugin`), quindi non è stato possibile produrre un jar eseguibile in questo ambiente.
- Non sono stati eseguiti test unitari automatizzati (nessun test incluso v1); la run CLI e le integrazioni con OpenAI/Docker restano scaricabili/da verificare in ambiente con accesso alla rete e Docker disponibile.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c956861ab08332bfdaf035e5c917a7)