### PR TITLE
Integrate Firecrawl web tool and enable AgenticExecutor in runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It transforms a simple repository into an executable system:
   Support for:
   - HTTP APIs  
   - Docker-based tools  
+  - Firecrawl web scraping/search/crawl  
 
 - **Pipeline orchestration**  
   Compose agents and tools into sequential workflows.
@@ -224,6 +225,13 @@ hubbers tool run browser.pinchtab --input "{\"action\":\"snapshot\",\"filter\":\
 
 # Browser automation - extract text
 hubbers tool run browser.pinchtab --input "{\"action\":\"extract_text\"}"
+
+
+# Firecrawl - scrape a page (requires FIRECRAWL_API_KEY)
+hubbers tool run web.firecrawl --input "{\"action\":\"scrape\",\"url\":\"https://example.com\",\"formats\":[\"markdown\"]}"
+
+# Firecrawl - search the web
+hubbers tool run web.firecrawl --input "{\"action\":\"search\",\"query\":\"AI agents Java SDK\",\"limit\":5}"
 ```
 
 ### Run Pipeline

--- a/docs/analisi-framework.md
+++ b/docs/analisi-framework.md
@@ -1,0 +1,77 @@
+# Analisi comparativa: Hubbers vs Manus vs OpenClaw vs Claude Code
+
+_Data analisi: 2 aprile 2026._
+
+## 1) Sintesi esecutiva
+
+- **Hubbers** è un runtime Java "artifact-first": definisci agenti/tool/pipeline in YAML versionati su Git e li esegui via CLI/Web API. È ideale per chi vuole **controllo architetturale, tipizzazione e orchestrazione deterministica** in un proprio repository.
+- **Claude Code** è un agente di coding in terminale/IDE, fortemente orientato alla produttività sviluppatore e all'ecosistema MCP/CI.
+- **OpenClaw** è un assistente personale self-hosted multi-canale (messaggistica/voice), con orientamento "always-on" e uso operativo quotidiano.
+- **Manus** è una piattaforma orientata a workflow applicativi con integrazioni (es. GitHub, MCP connectors) e collaborazione in task.
+
+In breve:
+- se vuoi un **framework runtime embeddabile e governabile in Git** → Hubbers;
+- se vuoi un **copilot agentico per sviluppo software** → Claude Code;
+- se vuoi un **assistente personale locale multi-canale** → OpenClaw;
+- se vuoi un **ambiente workflow/productivity con sync GitHub e connettori** → Manus.
+
+## 2) Cosa emerge dal codice di Hubbers
+
+### Architettura
+- Runtime centrato su `RuntimeFacade`, che espone esecuzione di agenti, tool e pipeline con validazione manifest prima del run.
+- Artifact repository locale + scanner directory (`agents/`, `tools/`, `pipelines/`) per discovery Git-native.
+- Pipeline eseguite in sequenza con `input_mapping` tra step e stato interno.
+
+### Estendibilità
+- Registro provider modello con implementazioni OpenAI + Ollama.
+- Executor tool basato su driver per tipo (`http`, `docker`, `rss`, `lucene.*`, `browser.pinchtab`, `csv.*`, `file ops`, `shell exec`, `process manage`).
+- API Web con endpoint per list/validate/save/run oltre alla CLI.
+
+### Nota tecnica importante
+- In `Bootstrap` viene istanziato anche `AgenticExecutor` (tool-calling + memory), ma il `RuntimeFacade` finale usa `AgentExecutor` classico: questo suggerisce che la parte "agentica" avanzata non è ancora fully wired nel percorso principale.
+
+## 3) Confronto strutturato
+
+| Criterio | Hubbers | Manus | OpenClaw | Claude Code |
+|---|---|---|---|---|
+| Posizionamento | Runtime framework Java per artifact YAML | Piattaforma workflow con connettori/MCP e collaborazione | Assistente personale self-hosted multi-canale | Agente di coding in terminale/IDE |
+| Modalità d'uso | CLI + Web API, repo locale | Web product + integrazioni (GitHub sync, collab) | Gateway locale, canali chat/voice, CLI | CLI/IDE/GitHub, comandi NL |
+| Unità di composizione | agent/tool/pipeline manifest | task/progetto con integrazioni | agent + skills + canali | sessione coding + tools/MCP |
+| Governance & Git | Molto alta (Git-native per design) | Alta lato progetto (sync bidirezionale GitHub) | Variabile, dipende dal setup self-hosted | Alta nel ciclo dev, ma tool-centric |
+| Estendibilità tool | Driver Java forti, schema validation | Connettori MCP/app integrations | Skills + integrazioni canale/dispositivo | MCP + plugin + automation CI |
+| Target primario | Team platform/engineering | Team prodotto/ops | Power user self-hosted | Developer individual/team |
+
+## 4) Gap/focus per portare Hubbers verso gli altri
+
+1. **Vs Claude Code (DX coding)**
+   - Migliorare UX per loop di coding (comandi ad alto livello tipo "fix, test, commit").
+   - Potenziare integrazione IDE e workflow PR nativi.
+
+2. **Vs OpenClaw (operatività always-on)**
+   - Aggiungere canali realtime (chat connectors) e gestione identità/permessi per utenti finali.
+   - Rafforzare runtime supervision/long-running tasks.
+
+3. **Vs Manus (workflow produttivo business)**
+   - Espandere catalogo connettori prebuilt e UI di orchestrazione collaborativa.
+   - Introdurre collaborazione multi-utente su task/pipeline con controllo costi/quote.
+
+## 5) Raccomandazione pratica
+
+Se il tuo obiettivo è costruire un **"control plane agentico enterprise"**:
+- mantieni Hubbers come nucleo (manifest + validazione + orchestrazione);
+- aggiungi uno strato "experience":
+  - **Developer experience** stile Claude Code,
+  - **connectors/workflow** stile Manus,
+  - **runtime always-on multi-canale** stile OpenClaw.
+
+In questo modo preservi il vantaggio di Hubbers (governance, deterministic execution, portabilità Java) senza rinunciare alla velocità d'adozione dei framework più "productized".
+
+## Fonti esterne consultate
+
+- Claude Code overview/docs: https://code.claude.com/docs/en/overview
+- Repository Claude Code: https://github.com/anthropics/claude-code
+- Repository OpenClaw: https://github.com/openclaw/openclaw
+- Sito/documentazione Manus:
+  - https://manus.im/
+  - https://manus.im/docs/website-builder/github-integration
+  - https://manus.im/docs/integrations/mcp-connectors

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <lucene.version>9.11.1</lucene.version>
         <slf4j.version>2.0.16</slf4j.version>
         <junit.version>5.11.3</junit.version>
+        <firecrawl.version>1.1.1</firecrawl.version>
         <native.maven.plugin.version>0.10.1</native.maven.plugin.version>
         <imageName>hubbers</imageName>
     </properties>
@@ -62,6 +63,12 @@
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analysis-common</artifactId>
             <version>${lucene.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.firecrawl</groupId>
+            <artifactId>firecrawl-java</artifactId>
+            <version>${firecrawl.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/hubbers/app/Bootstrap.java
+++ b/src/main/java/org/hubbers/app/Bootstrap.java
@@ -1,7 +1,5 @@
 package org.hubbers.app;
 
-import org.hubbers.agent.AgentExecutor;
-import org.hubbers.agent.AgentPromptBuilder;
 import org.hubbers.artifact.ArtifactScanner;
 import org.hubbers.artifact.LocalArtifactRepository;
 import org.hubbers.config.OllamaConfig;
@@ -13,6 +11,7 @@ import org.hubbers.pipeline.InputMapper;
 import org.hubbers.pipeline.PipelineExecutor;
 import org.hubbers.tool.DockerToolDriver;
 import org.hubbers.tool.FileOpsToolDriver;
+import org.hubbers.tool.FirecrawlToolDriver;
 import org.hubbers.tool.HttpToolDriver;
 import org.hubbers.tool.CsvReadToolDriver;
 import org.hubbers.tool.CsvWriteToolDriver;
@@ -48,12 +47,11 @@ public class Bootstrap {
         ));
 
         var schemaValidator = new SchemaValidator();
-        var agentExecutor = new AgentExecutor(modelRegistry, new AgentPromptBuilder(), schemaValidator, jsonMapper);
-
         var toolExecutor = new ToolExecutor(List.of(
                 new HttpToolDriver(httpClient, jsonMapper),
                 new DockerToolDriver(jsonMapper),
                 new RssToolDriver(httpClient, jsonMapper),
+                new FirecrawlToolDriver(jsonMapper),
                 new LuceneVectorContextToolDriver(jsonMapper),
                 new LuceneVectorUpsertToolDriver(jsonMapper),
                 new LuceneVectorSearchToolDriver(jsonMapper),
@@ -77,8 +75,8 @@ public class Bootstrap {
                 jsonMapper
         );
 
-        var pipelineExecutor = new PipelineExecutor(repository, agentExecutor, toolExecutor, new InputMapper(jsonMapper));
+        var pipelineExecutor = new PipelineExecutor(repository, agenticExecutor, toolExecutor, new InputMapper(jsonMapper));
 
-        return new RuntimeFacade(repository, agentExecutor, toolExecutor, pipelineExecutor, new ManifestValidator());
+        return new RuntimeFacade(repository, agenticExecutor, toolExecutor, pipelineExecutor, new ManifestValidator());
     }
 }

--- a/src/main/java/org/hubbers/app/RuntimeFacade.java
+++ b/src/main/java/org/hubbers/app/RuntimeFacade.java
@@ -1,7 +1,7 @@
 package org.hubbers.app;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.hubbers.agent.AgentExecutor;
+import org.hubbers.agent.AgenticExecutor;
 import org.hubbers.artifact.ArtifactRepository;
 import org.hubbers.execution.RunResult;
 import org.hubbers.pipeline.PipelineExecutor;
@@ -12,13 +12,13 @@ import java.util.List;
 
 public class RuntimeFacade {
     private final ArtifactRepository artifactRepository;
-    private final AgentExecutor agentExecutor;
+    private final AgenticExecutor agentExecutor;
     private final ToolExecutor toolExecutor;
     private final PipelineExecutor pipelineExecutor;
     private final ManifestValidator manifestValidator;
 
     public RuntimeFacade(ArtifactRepository artifactRepository,
-                         AgentExecutor agentExecutor,
+                         AgenticExecutor agentExecutor,
                          ToolExecutor toolExecutor,
                          PipelineExecutor pipelineExecutor,
                          ManifestValidator manifestValidator) {
@@ -33,7 +33,7 @@ public class RuntimeFacade {
         var manifest = artifactRepository.loadAgent(name);
         var validation = manifestValidator.validateAgent(manifest);
         if (!validation.isValid()) return RunResult.failed(String.join(", ", validation.getErrors()));
-        return agentExecutor.execute(manifest, input);
+        return agentExecutor.execute(manifest, input, null);
     }
 
     public RunResult runTool(String name, JsonNode input) {

--- a/src/main/java/org/hubbers/pipeline/PipelineExecutor.java
+++ b/src/main/java/org/hubbers/pipeline/PipelineExecutor.java
@@ -1,7 +1,7 @@
 package org.hubbers.pipeline;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.hubbers.agent.AgentExecutor;
+import org.hubbers.agent.AgenticExecutor;
 import org.hubbers.artifact.ArtifactRepository;
 import org.hubbers.execution.RunResult;
 import org.hubbers.manifest.pipeline.PipelineManifest;
@@ -13,12 +13,12 @@ import org.slf4j.LoggerFactory;
 public class PipelineExecutor {
     private static final Logger log = LoggerFactory.getLogger(PipelineExecutor.class);
     private final ArtifactRepository artifactRepository;
-    private final AgentExecutor agentExecutor;
+    private final AgenticExecutor agentExecutor;
     private final ToolExecutor toolExecutor;
     private final InputMapper inputMapper;
 
     public PipelineExecutor(ArtifactRepository artifactRepository,
-                            AgentExecutor agentExecutor,
+                            AgenticExecutor agentExecutor,
                             ToolExecutor toolExecutor,
                             InputMapper inputMapper) {
         this.artifactRepository = artifactRepository;
@@ -46,7 +46,7 @@ public class PipelineExecutor {
             if (step.getTool() != null && !step.getTool().isBlank()) {
                 stepResult = toolExecutor.execute(artifactRepository.loadTool(step.getTool()), stepInput);
             } else {
-                stepResult = agentExecutor.execute(artifactRepository.loadAgent(step.getAgent()), stepInput);
+                stepResult = agentExecutor.execute(artifactRepository.loadAgent(step.getAgent()), stepInput, null);
             }
             
             if (stepResult.getStatus() != org.hubbers.execution.ExecutionStatus.SUCCESS) {

--- a/src/main/java/org/hubbers/tool/FirecrawlToolDriver.java
+++ b/src/main/java/org/hubbers/tool/FirecrawlToolDriver.java
@@ -1,0 +1,184 @@
+package org.hubbers.tool;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.models.CrawlJob;
+import com.firecrawl.models.CrawlOptions;
+import com.firecrawl.models.Document;
+import com.firecrawl.models.MapData;
+import com.firecrawl.models.MapOptions;
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.SearchData;
+import com.firecrawl.models.SearchOptions;
+import org.hubbers.manifest.tool.ToolManifest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FirecrawlToolDriver implements ToolDriver {
+    private final ObjectMapper mapper;
+
+    public FirecrawlToolDriver(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public String type() {
+        return "firecrawl";
+    }
+
+    @Override
+    public JsonNode execute(ToolManifest manifest, JsonNode input) {
+        FirecrawlClient client = createClient(manifest);
+        String action = resolveAction(manifest, input);
+
+        return switch (action) {
+            case "scrape" -> scrape(client, manifest, input);
+            case "crawl" -> crawl(client, manifest, input);
+            case "search" -> search(client, input);
+            case "map" -> map(client, input);
+            default -> throw new IllegalArgumentException("Unsupported firecrawl action: " + action);
+        };
+    }
+
+    private JsonNode scrape(FirecrawlClient client, ToolManifest manifest, JsonNode input) {
+        String url = resolveUrl(manifest, input);
+        ScrapeOptions options = ScrapeOptions.builder()
+                .formats(resolveFormats(input))
+                .onlyMainContent(input.path("only_main_content").asBoolean(true))
+                .waitFor(input.path("wait_for").asInt(5000))
+                .build();
+        Document document = client.scrape(url, options);
+
+        ObjectNode out = mapper.createObjectNode();
+        out.put("action", "scrape");
+        out.put("url", url);
+        out.set("document", mapper.valueToTree(document));
+        return out;
+    }
+
+    private JsonNode crawl(FirecrawlClient client, ToolManifest manifest, JsonNode input) {
+        String url = resolveUrl(manifest, input);
+        CrawlOptions options = CrawlOptions.builder()
+                .limit(input.path("limit").asInt(10))
+                .maxDiscoveryDepth(input.path("max_discovery_depth").asInt(2))
+                .scrapeOptions(ScrapeOptions.builder()
+                        .formats(resolveFormats(input))
+                        .onlyMainContent(input.path("only_main_content").asBoolean(true))
+                        .waitFor(input.path("wait_for").asInt(5000))
+                        .build())
+                .build();
+        CrawlJob crawlJob = client.crawl(url, options);
+
+        ObjectNode out = mapper.createObjectNode();
+        out.put("action", "crawl");
+        out.put("url", url);
+        out.set("crawl", mapper.valueToTree(crawlJob));
+        return out;
+    }
+
+    private JsonNode search(FirecrawlClient client, JsonNode input) {
+        String query = text(input, "query");
+        if (query == null || query.isBlank()) {
+            throw new IllegalArgumentException("Missing input.query for firecrawl search");
+        }
+
+        SearchData data = client.search(query, SearchOptions.builder().limit(input.path("limit").asInt(10)).build());
+
+        ObjectNode out = mapper.createObjectNode();
+        out.put("action", "search");
+        out.put("query", query);
+        out.set("results", mapper.valueToTree(data));
+        return out;
+    }
+
+    private JsonNode map(FirecrawlClient client, JsonNode input) {
+        String url = text(input, "url");
+        if (url == null || url.isBlank()) {
+            throw new IllegalArgumentException("Missing input.url for firecrawl map");
+        }
+
+        MapOptions.Builder builder = MapOptions.builder()
+                .limit(input.path("limit").asInt(100));
+        String search = text(input, "search");
+        if (search != null && !search.isBlank()) {
+            builder.search(search);
+        }
+
+        MapData data = client.map(url, builder.build());
+
+        ObjectNode out = mapper.createObjectNode();
+        out.put("action", "map");
+        out.put("url", url);
+        out.set("data", mapper.valueToTree(data));
+        return out;
+    }
+
+    private FirecrawlClient createClient(ToolManifest manifest) {
+        String apiKey = config(manifest, "api_key");
+        if (apiKey != null && !apiKey.isBlank()) {
+            return FirecrawlClient.builder().apiKey(apiKey).build();
+        }
+        return FirecrawlClient.fromEnv();
+    }
+
+    private String resolveAction(ToolManifest manifest, JsonNode input) {
+        String inputAction = text(input, "action");
+        if (inputAction != null && !inputAction.isBlank()) {
+            return inputAction.trim().toLowerCase();
+        }
+        String configAction = config(manifest, "default_action");
+        if (configAction != null && !configAction.isBlank()) {
+            return configAction.trim().toLowerCase();
+        }
+        return "scrape";
+    }
+
+    private String resolveUrl(ToolManifest manifest, JsonNode input) {
+        String inputUrl = text(input, "url");
+        if (inputUrl != null && !inputUrl.isBlank()) {
+            return inputUrl;
+        }
+        String configUrl = config(manifest, "base_url");
+        if (configUrl != null && !configUrl.isBlank()) {
+            return configUrl;
+        }
+        throw new IllegalArgumentException("Missing url for firecrawl action");
+    }
+
+    private List<Object> resolveFormats(JsonNode input) {
+        JsonNode formatsNode = input.get("formats");
+        if (formatsNode == null || !formatsNode.isArray() || formatsNode.isEmpty()) {
+            return List.of((Object) "markdown");
+        }
+
+        ArrayNode arrayNode = (ArrayNode) formatsNode;
+        List<Object> formats = new ArrayList<>();
+        for (JsonNode node : arrayNode) {
+            if (node.isTextual()) {
+                formats.add(node.asText());
+            }
+        }
+
+        if (formats.isEmpty()) {
+            return List.of((Object) "markdown");
+        }
+        return formats;
+    }
+
+    private String text(JsonNode input, String field) {
+        JsonNode node = input.get(field);
+        return node != null && node.isTextual() ? node.asText() : null;
+    }
+
+    private String config(ToolManifest manifest, String key) {
+        if (manifest.getConfig() == null) {
+            return null;
+        }
+        Object value = manifest.getConfig().get(key);
+        return value == null ? null : value.toString();
+    }
+}


### PR DESCRIPTION
### Motivation
- Add web scraping/search/crawl capabilities via Firecrawl and wire agentic (tool-calling + memory) behavior into the main runtime pipeline. 

### Description
- Add a new `FirecrawlToolDriver` implementing `ToolDriver` to support `scrape`, `crawl`, `search`, and `map` actions using the Firecrawl Java client.  
- Add the Firecrawl dependency and version property to `pom.xml` (`com.firecrawl:firecrawl-java:${firecrawl.version}`).  
- Register `FirecrawlToolDriver` in `Bootstrap` and replace the classical `AgentExecutor` with `AgenticExecutor` for runtime and pipeline execution.  
- Update `RuntimeFacade` and `PipelineExecutor` to use `AgenticExecutor` and adapt calls to `agentExecutor.execute(...)` to the new signature with the extra context parameter.  
- Update `README.md` with `web.firecrawl` CLI examples and add a comparative analysis document at `docs/analisi-framework.md`.

### Testing
- Built the project and ran the existing unit test suite with `mvn test`, and the test suite completed successfully.  
- Packaged the artifact with `mvn package` to verify shading and dependency resolution completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce33136b4c8332b4b461d5b11ee94f)